### PR TITLE
add request volume threshold config

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tech.gojek/bulwark "1.0.1"
+(defproject tech.gojek/bulwark "1.2.0"
   :description "Hystrix for Clojurists"
   :url "https://github.com/gojektech/bulwark"
   :license {:name "Apache License, Version 2.0"

--- a/test/bulwark/core_test.clj
+++ b/test/bulwark/core_test.clj
@@ -13,8 +13,20 @@
                                           :breaker-sleep-window-ms            500
                                           :breaker-error-threshold-percentage 20
                                           :execution-timeout-ms               100
+                                          :request-volume-threshold           20
                                           :fallback-fn                        fallback}
                      "success")]
+      (is (= result "success"))))
+
+  (testing "Successful call with default hystrix config"
+    (let [fallback (fn [_]
+                     "failure")
+          result   (bulwark/with-hystrix {:group-key                          "foo"
+                                          :command-key                        "foo"
+                                          :thread-pool-key                    "foo"
+                                          :thread-count                       2
+                                          :fallback-fn                        fallback}
+                                         "success")]
       (is (= result "success"))))
 
   (testing "Fallback when exception is thrown"
@@ -28,6 +40,7 @@
                                                   :thread-count                       2
                                                   :breaker-sleep-window-ms            500
                                                   :breaker-error-threshold-percentage 20
+                                                  :request-volume-threshold           20
                                                   :execution-timeout-ms               100
                                                   :fallback-fn                        fallback}
                              (throw (ex-info "foo" {:error "foo"}))
@@ -47,6 +60,7 @@
                                             :thread-count                       2
                                             :breaker-sleep-window-ms            500
                                             :breaker-error-threshold-percentage 20
+                                            :request-volume-threshold           20
                                             :execution-timeout-ms               100
                                             :fallback-fn                        fallback}
                        (Thread/sleep 200)


### PR DESCRIPTION
Currently it does not have support of client adding a request volume threshold config. And also the hystrix parameters are not optional.