### PR TITLE
clear mdc context only when fallback func runs on separate thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to [tech.gojek/bulwark](https://clojars.org/tech.gojek/bulwa
 
 ## [Unreleased]
 
+## [1.2.1]
+### Added
+- check if fallback func is running in separate thread before clearing MDC
+
 ## [1.2.0]
 ### Added
 - `breaker-request-volume-threshold` config parameter.

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject tech.gojek/bulwark "1.2.0"
+(defproject tech.gojek/bulwark "1.2.1"
   :description "Hystrix for Clojurists"
   :url "https://github.com/gojektech/bulwark"
   :license {:name "Apache License, Version 2.0"
@@ -14,5 +14,6 @@
                                    [lein-cljfmt "0.6.3"]
                                    [lein-cloverage "1.0.13"]
                                    [lein-kibit "0.1.6"]]
-                    :dependencies [[org.clojure/clojure "1.9.0"]]}}
+                    :dependencies [[org.clojure/clojure "1.9.0"]
+                                   [org.apache.logging.log4j/log4j-slf4j-impl "2.1"]]}}
   :cljfmt {:indents {bulwark/with-hystrix [[:inner 0]]}})

--- a/project.clj
+++ b/project.clj
@@ -15,5 +15,5 @@
                                    [lein-cloverage "1.0.13"]
                                    [lein-kibit "0.1.6"]]
                     :dependencies [[org.clojure/clojure "1.9.0"]
-                                   [org.apache.logging.log4j/log4j-slf4j-impl "2.1"]]}}
+                                   [org.apache.logging.log4j/log4j-slf4j-impl "2.17.2"]]}}
   :cljfmt {:indents {bulwark/with-hystrix [[:inner 0]]}})


### PR DESCRIPTION
Co-authored-by: sauravomar01 <sauravomar01@gmail.com>

Issue: MDC getting cleared when circuit breaker is open
 - the fallback wrapper in bulwark clears the MDC context
 - when circuit break is open the fallback function is executed in the calling thread (main thread)
 - this clears the MDC context for main thread.

Solution: 
 - clear the context in the fallback wrapper only when the fallback function is running in a separate thread.
